### PR TITLE
商品詳細表示機能の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 | status       | integer   | null: false                    |
 | delivery-fee | integer   | null: false                    |
 | area         | integer   | null: false                    |
-| days         | integer   | null: false                    |
+| day          | integer   | null: false                    |
 | price        | integer   | null: false                    |
 | user         | reference | null: false, foreign_key: true |
 ### Association

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,14 +1,11 @@
 class ItemsController < ApplicationController
-  before_action :move_to_index, except: [:index]
+  before_action :move_to_index, except: [:index, :show]
 
   def index
     @items = Item.order('created_at DESC')
   end
 
-  def move_to_index
-    redirect_to action: :index unless user_signed_in?
-  end
-
+  
   def new
     @items = Item.new
   end
@@ -17,15 +14,24 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     if @item.valid?
       @item.save
-      render :index
+      redirect_to action: :index
     else
       render :new
     end
   end
 
+  def show
+    @item = Item.find(params[:id])
+  end
+
   private
 
   def item_params
-    params.require(:item).permit(:name, :explanation, :category_id, :status_id, :delivery_fee_id, :area_id, :days_id, :price, :image).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :explanation, :category_id, :status_id, :delivery_fee_id, :area_id, :day_id, :price, :image).merge(user_id: current_user.id)
   end
+
+  def move_to_index
+    redirect_to action: :index unless user_signed_in?
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,7 +5,6 @@ class ItemsController < ApplicationController
     @items = Item.order('created_at DESC')
   end
 
-  
   def new
     @items = Item.new
   end
@@ -33,5 +32,4 @@ class ItemsController < ApplicationController
   def move_to_index
     redirect_to action: :index unless user_signed_in?
   end
-
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+
+ def show
+  @nickname = current_user.nickname
+  @item = current_user.item
+ end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,6 @@
 class UsersController < ApplicationController
-
- def show
-  @nickname = current_user.nickname
-  @item = current_user.item
- end
+  def show
+    @nickname = current_user.nickname
+    @item = current_user.item
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -17,6 +17,6 @@ class Item < ApplicationRecord
     validates :delivery_fee_id, numericality: { other_than: 1 }
     validates :area_id, numericality: { other_than: 0 }
     validates :day_id, numericality: { other_than: 1 }
-    validates :price, numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range'}
+    validates :price, numericality: { greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range'}
   end
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -16,7 +16,7 @@ class Item < ApplicationRecord
     validates :status_id, numericality: { other_than: 1 }
     validates :delivery_fee_id, numericality: { other_than: 1 }
     validates :area_id, numericality: { other_than: 0 }
-    validates :days_id, numericality: { other_than: 1 }
+    validates :day_id, numericality: { other_than: 1 }
     validates :price, numericality: {greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'is out of setting range'}
   end
 end

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -129,7 +129,7 @@
 
       <%# 商品のインスタンス変数になにか入っている場合、中身のすべてを展開できるようにしましょう %>
       <li class='list'>
-        <%= link_to "#" do %>
+        <%= link_to item_path(item.id), method: :get do %>
         <div class='item-img-content'>
           <%= image_tag item.image, class: "item-img" %>
           

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -81,7 +81,7 @@
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:days_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:day_id, Day.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -1,13 +1,12 @@
 <%= render "shared/header" %>
-
 <%# 商品の概要 %>
 <div class="item-show">
   <div class="item-box">
     <h2 class="name">
-      <%= "商品名" %>
+      <%= @item.name %>
     </h2>
     <div class='item-img-content'>
-      <%= image_tag "item-sample.png" ,class:"item-box-img" %>
+      <%= image_tag @item.image, class:"item-box-img" %>
       <%# 商品が売れている場合は、sold outを表示しましょう %>
       <div class='sold-out'>
         <span>Sold Out!!</span>
@@ -16,7 +15,7 @@
     </div>
     <div class="item-price-box">
       <span class="item-price">
-        ¥ 999,999,999
+        <%= @item.price %>
       </span>
       <span class="item-postage">
         (税込) 送料込み
@@ -24,46 +23,48 @@
     </div>
 
     <%# ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
-
+    <% if user_signed_in? && current_user.id == @item.user_id %>
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-
+    <% elsif user_signed_in? %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
+    <% end %>
     <%# //商品が売れていない場合はこちらを表示しましょう %>
 
 
     <%# //ログインしているユーザーと出品しているユーザーが、同一人物の場合と同一人物ではない場合で、処理を分けましょう %>
 
     <div class="item-explain-box">
-      <span><%= "商品説明" %></span>
+    
+      <span><%= @item.explanation %></span>
     </div>
     <table class="detail-table">
       <tbody>
         <tr>
           <th class="detail-item">出品者</th>
-          <td class="detail-value"><%= "出品者名" %></td>
+          <td class="detail-value"><%= @item.user.nickname %></td>
         </tr>
         <tr>
           <th class="detail-item">カテゴリー</th>
-          <td class="detail-value"><%= "カテゴリー名" %></td>
+          <td class="detail-value"><%= @item.category.name %></td>
         </tr>
         <tr>
           <th class="detail-item">商品の状態</th>
-          <td class="detail-value"><%= "商品の状態" %></td>
+          <td class="detail-value"><%= @item.status.name %></td>
         </tr>
         <tr>
           <th class="detail-item">配送料の負担</th>
-          <td class="detail-value"><%= "発送料の負担" %></td>
+          <td class="detail-value"><%= @item.delivery_fee.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送元の地域</th>
-          <td class="detail-value"><%= "発送元の地域" %></td>
+          <td class="detail-value"><%= @item.area.name %></td>
         </tr>
         <tr>
           <th class="detail-item">発送日の目安</th>
-          <td class="detail-value"><%= "発送日の目安" %></td>
+          <td class="detail-value"><%= @item.day.name %></td>
         </tr>
       </tbody>
     </table>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -27,7 +27,7 @@
     <%= link_to '商品の編集', "#", method: :get, class: "item-red-btn" %>
     <p class='or-text'>or</p>
     <%= link_to '削除', "#", method: :delete, class:'item-destroy' %>
-    <% elsif user_signed_in? %>
+    <% else %>
     <%# 商品が売れていない場合はこちらを表示しましょう %>
     <%= link_to '購入画面に進む', "#" ,class:"item-red-btn"%>
     <% end %>
@@ -103,7 +103,7 @@
       後ろの商品 ＞
     </a>
   </div>
-  <a href="#" class='another-item'><%= "商品のカテゴリー名" %>をもっと見る</a>
+  <a href="#" class='another-item'><%= @item.category.name %>をもっと見る</a>
 </div>
 
 <%= render "shared/footer" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create]
+  resources :items, only: [:index, :new, :create, :show]
+  resources :users, only: :show
 end

--- a/db/migrate/20200917031729_create_items.rb
+++ b/db/migrate/20200917031729_create_items.rb
@@ -7,7 +7,7 @@ class CreateItems < ActiveRecord::Migration[6.0]
       t.integer :status_id,        null: false
       t.integer :delivery_fee_id,  null: false
       t.integer :area_id,          null: false
-      t.integer :days_id,          null: false
+      t.integer :day_id,          null: false
       t.integer :price,            null: false
       t.references :user,          null: false,   foreign_key: true
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2020_09_18_074107) do
     t.integer "status_id", null: false
     t.integer "delivery_fee_id", null: false
     t.integer "area_id", null: false
-    t.integer "days_id", null: false
+    t.integer "day_id", null: false
     t.integer "price", null: false
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     status_id { 2 }
     delivery_fee_id { 2 }
     area_id { 2 }
-    days_id { 2 }
+    day_id  { 2 }
     price { '2000' }
     association :user
 

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the UsersHelper. For example:
+#
+# describe UsersHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe UsersHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -44,10 +44,10 @@ RSpec.describe Item, type: :model do
       @items.valid?
       expect(@items.errors.full_messages).to include('Area must be other than 0')
     end
-    it 'days_idが空だと保存できないこと' do
-      @items.days_id = 1
+    it 'day_idが空だと保存できないこと' do
+      @items.day_id = 1
       @items.valid?
-      expect(@items.errors.full_messages).to include('Days must be other than 1')
+      expect(@items.errors.full_messages).to include('Day must be other than 1')
     end
     it 'priceが空だと保存できないこと' do
       @items.price = nil

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe "Users", type: :request do
+
+end

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -1,5 +1,4 @@
 require 'rails_helper'
 
-RSpec.describe "Users", type: :request do
-
+RSpec.describe 'Users', type: :request do
 end


### PR DESCRIPTION
#what
商品詳細表示機能の実装

#why
商品詳細表示機能の実装をする為。

追記：
まだ商品購入機能を実装していないので売却済みの商品は、「sold out」の文字が表示されるようになっている機能がまだ実装出来ていないので、soldoutが出品した画像に出てしまっています。

ログイン状態で自分の出品した商品の詳細ページに移動すると
編集と消去ボタンが表示される
https://gyazo.com/27e7103430efc0560edbe705a3b8c844
自分が出品した商品の詳細ページ
https://gyazo.com/9839e40e68c89d918ae6693a3c152213

ログインした状態で他のユーザーが出品した商品の詳細ページに移動すると
購入画面に進むボタンが表示される
https://gyazo.com/162d92b96dfb31588efb007a9965acc5
他のユーザーが出品した商品の詳細ページ
https://gyazo.com/12341bb4be66a857fabdb837e2e30449

ログインしていないユーザーは詳細ページのみ閲覧出来る
https://gyazo.com/5a98f71155740a653a8b2ebdb8d01149
詳細ページ
https://gyazo.com/4f4f4e164518e82ca8455b186fe03d4c

お願い致します。